### PR TITLE
+New platform support in Delphi 13 Update 1: WinARM64EC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ Note: The `tag-release` script will fail if it does not find a matching version
 section here.
 
 ---
+
+## [1.4.0] Unreleased
+
+- Add support for `WinARM64EC` as Delphi 13.1 just started supporting this new platform
+  Schema + Data versions bumped from `1.0.0` to `1.1.0` due to new platform support.
+  Latest schema becomes 1.1.0: `https://continuous-delphi.github.io/schemas/delphi-compiler-versions.schema.json`
+  Added `schemas/1.0.0` and `schemas/1.1.0` to capture version-specific schemas
+  [#22](https://github.com/continuous-delphi/delphi-compiler-versions/issues/22)
+
 ## [1.3.0] - 2026-03-15
 
 - Corrected iOS+iOSSimulator platforms, will now have iOS32 + iOS64 and

--- a/data/delphi-compiler-versions.json
+++ b/data/delphi-compiler-versions.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": "1.0.0",
-  "dataVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
+  "dataVersion": "1.1.0",
   "meta": {
-    "generatedUtcDate": "2026-03-05",
+    "generatedUtcDate": "2026-03-21",
     "scope": {
       "includeFromVer": "VER90",
       "excluded": [
@@ -347,10 +347,11 @@
       "packageVersion": "370",
       "regKeyRelativePath": "\\Software\\Embarcadero\\BDS\\37.0",
       "supportedBuildSystems": ["DCC", "MSBuild"],
-      "supportedPlatforms": ["Win32", "Win64", "macOS64", "macOSARM64", "iOS64", "iOSSimulator64", "Android32", "Android64", "Linux64"],
+      "supportedPlatforms": ["Win32", "Win64", "macOS64", "macOSARM64", "iOS64", "iOSSimulator64", "Android32", "Android64", "Linux64", "WinARM64EC"],
       "aliases": ["Delphi 13", "Florence", "13 Florence"],
       "notes": [
-        "RAD Studio 13 unifies internal version numbers to 37 (registry, RTL, packages)."
+        "RAD Studio 13 unifies internal version numbers to 37 (registry, RTL, packages).",
+        "Update 1 for RAD Studio 13 Florence added support for WinARM64EC"
       ]
     }
   ]

--- a/generated/DELPHI_COMPILER_VERSIONS.inc
+++ b/generated/DELPHI_COMPILER_VERSIONS.inc
@@ -9,9 +9,9 @@
   Metadata
   --------------------------------------------------------------------------- }
 
-{$DEFINE CD_DELPHI_SCHEMA_1_0_0}
-{$DEFINE CD_DELPHI_DATA_1_0_0}
-{$DEFINE CD_DELPHI_GENERATED_2026_03_05}
+{$DEFINE CD_DELPHI_SCHEMA_1_1_0}
+{$DEFINE CD_DELPHI_DATA_1_1_0}
+{$DEFINE CD_DELPHI_GENERATED_2026_03_21}
 
 { ---------------------------------------------------------------------------
   Unknown version detection
@@ -483,5 +483,9 @@
 
 {$IFDEF CD_DELPHI_XE2_OR_LATER}
   {$DEFINE CD_DELPHI_SUPPORTS_PLATFORM_WIN64}
+{$ENDIF}
+
+{$IFDEF CD_DELPHI_13_OR_LATER}
+  {$DEFINE CD_DELPHI_SUPPORTS_PLATFORM_WINARM64EC}
 {$ENDIF}
 

--- a/generated/DelphiCompilerVersions.pas
+++ b/generated/DelphiCompilerVersions.pas
@@ -15,7 +15,8 @@ type
     MacOS64Target,
     MacOSARM64Target,
     Win32Target,
-    Win64Target
+    Win64Target,
+    WinARM64ECTarget
   );
 
   TDelphiPlatforms = set of TDelphiPlatform;
@@ -41,8 +42,8 @@ type
   PDelphiVersion = ^TDelphiVersion;
 
 const
-  CD_SCHEMA_VERSION = '1.0.0';
-  CD_DATA_VERSION   = '1.0.0';
+  CD_SCHEMA_VERSION = '1.1.0';
+  CD_DATA_VERSION   = '1.1.0';
 
   DelphiVersions: array[0..26] of TDelphiVersion =
   (
@@ -312,7 +313,7 @@ const
       ProductName: 'Delphi 13 Florence';
       PackageVersion: '370';
       RegKeyRelativePath: '\Software\Embarcadero\BDS\37.0';
-      SupportedPlatforms: [Android32Target, Android64Target, IOS64Target, IOSSimulator64Target, Linux64Target, MacOS64Target, MacOSARM64Target, Win32Target, Win64Target];
+      SupportedPlatforms: [Android32Target, Android64Target, IOS64Target, IOSSimulator64Target, Linux64Target, MacOS64Target, MacOSARM64Target, Win32Target, Win64Target, WinARM64ECTarget];
       SupportedBuildSystems: [DCCSystem, MSBuildSystem];
       AliasesCsv: 'Delphi 13;Florence;13 Florence';
     )

--- a/generated/PlatformSupport.md
+++ b/generated/PlatformSupport.md
@@ -1,5 +1,4 @@
 <!-- Generated from data/delphi-compiler-versions.json -- do not edit manually -->
-<!-- SchemaVersion: 1.0.0  DataVersion: 1.0.0  Generated: 2026-03-05 -->
 
 # Platform Support by Delphi Version
 
@@ -14,6 +13,7 @@
 |:--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | Win32 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓⁺ |
 | Win64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓⁺ |  |  |  |  |  |  |  |  |  |  |  |  |
+| WinARM64EC | ✓⁺ |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
 | macOS32 |  |  |  |  |  | ✓⁻ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓⁺ |  |  |  |  |  |  |  |  |  |  |  |  |
 | macOS64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓⁺ |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
 | macOSARM64 | ✓ | ✓ | ✓⁺ |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
@@ -28,4 +28,4 @@
 ---
 
 _Generated from data/delphi-compiler-versions.json -- 
-dataVersion 1.0.0, schemaVersion 1.0.0._
+dataVersion 1.1.0, schemaVersion 1.1.0._

--- a/schemas/1.0.0/delphi-compiler-versions.schema.json
+++ b/schemas/1.0.0/delphi-compiler-versions.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://continuous-delphi.github.io/delphi-compiler-versions/schemas/delphi-compiler-versions.schema.json",
+  "$id": "https://continuous-delphi.github.io/delphi-compiler-versions/schemas/1.0.0/delphi-compiler-versions.schema.json"
   "title": "Continuous Delphi - Canonical List of Compiler Versions",
   "type": "object",
   "additionalProperties": false,
@@ -15,7 +15,7 @@
       "description": "Schema version for this document (semantic versioning).",
       "pattern": "^\\d+\\.\\d+\\.\\d+$",
       "examples": [
-        "1.1.0"
+        "1.0.0"
       ]
     },
     "dataVersion": {
@@ -23,7 +23,7 @@
       "description": "Dataset version for the contents of this file (semantic versioning). Independent of schemaVersion.",
       "pattern": "^\\d+\\.\\d+\\.\\d+$",
       "examples": [
-        "1.1.0"
+        "0.3.0"
       ]
     },
     "meta": {
@@ -75,8 +75,7 @@
         "iOSSimulator32",
         "iOSSimulator64",
         "Android32",
-        "Android64",
-        "WinARM64EC"
+        "Android64"
       ],
       "description": "A supported target platform identifier."
     },
@@ -187,8 +186,8 @@
   },
   "examples": [
     {
-      "schemaVersion": "1.1.0",
-      "dataVersion": "1.1.0",
+      "schemaVersion": "1.0.0",
+      "dataVersion": "0.3.0",
       "versions": [
         {
           "verDefine": "VER370",

--- a/schemas/1.1.0/delphi-compiler-versions.schema.json
+++ b/schemas/1.1.0/delphi-compiler-versions.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://continuous-delphi.github.io/delphi-compiler-versions/schemas/delphi-compiler-versions.schema.json",
+  "$id": "https://continuous-delphi.github.io/delphi-compiler-versions/schemas/1.1.0/delphi-compiler-versions.schema.json"
   "title": "Continuous Delphi - Canonical List of Compiler Versions",
   "type": "object",
   "additionalProperties": false,

--- a/tools/generate-platform-support-md.ps1
+++ b/tools/generate-platform-support-md.ps1
@@ -84,7 +84,7 @@ $versionCount = $versions.Count
 # ---------------------------------------------------------------------------
 
 $platformOrder = @(
-  'Win32', 'Win64',
+  'Win32', 'Win64', 'WinARM64EC',
   'macOS32', 'macOS64', 'macOSARM64',
   'iOS32', 'iOSSimulator32',
   'iOS64', 'iOSSimulator64',
@@ -162,12 +162,10 @@ function Get-Cell([string]$platform, [int]$displayIndex) {
 $sb = [System.Text.StringBuilder]::new()
 function Emit([string]$line = '') { [void]$sb.AppendLine($line) }
 
-$genDate       = if ($data.meta -and $data.meta.generatedUtcDate) { $data.meta.generatedUtcDate } else { '' }
 $dataVersion   = $data.dataVersion
 $schemaVersion = $data.schemaVersion
 
 Emit '<!-- Generated from data/delphi-compiler-versions.json -- do not edit manually -->'
-Emit "<!-- SchemaVersion: $schemaVersion  DataVersion: $dataVersion  Generated: $genDate -->"
 Emit ''
 Emit '# Platform Support by Delphi Version'
 Emit ''


### PR DESCRIPTION
Bump data+schema version to 1.1.0
Regenerated INC+PAS+SupportMatrix files
Captured schemas at 1.0.0 and 1.1.0, updated non-versioned schema to 1.1.0 New release 1.4.0 to be done after workflow passes All 63 tests pass
For Issue #22